### PR TITLE
.NET Core Support

### DIFF
--- a/DeviceDetector.NET.NetCore.nuspec
+++ b/DeviceDetector.NET.NetCore.nuspec
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    <id>DeviceDetector.NET.NetCore</id>
+    <version>3.9.2.2</version>
+    <title>DeviceDetector.NET.NetCore</title>
+    <authors>totpero</authors>
+    <owners>totpero</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <licenseUrl>https://github.com/totpero/DeviceDetector.NET/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/totpero/DeviceDetector.NET</projectUrl>
+    <description>The Universal Device Detection library for .NET that parses User Agents and detects devices (desktop, tablet, mobile, tv, cars, console, etc.), clients (browsers, feed readers, media players, PIMs, ...), operating systems, brands and models. This is a port of the popular PHP device-detector library to C#. For the most part you can just follow the documentation for device-detector with no issue.</description>
+    <summary>The Universal Device Detection library will parse any User Agent and detect the browser, operating system, device used (desktop, tablet, mobile, tv, cars, console, etc.), brand and model.</summary>
+    <copyright>Copyright © www.totpe.ro</copyright>
+    <tags>parse detection-library user-agent bot-detection mobile-detection desktop tablet mobile tv cars console</tags>
+    <dependencies>
+      <group targetFramework=".NETCoreApp2.0">
+        <dependency id="YamlDotNet.NetCore" version="1.0.0" />
+      </group>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="src\DeviceDetector.NET\bin\Debug\netcoreapp2.0\DeviceDetector.NET.NetCore.dll" target="lib\netcoreapp2.0\DeviceDetector.NET.NetCore.dll" />
+  </files>
+</package>

--- a/DeviceDetector.NET.NetCore.sln
+++ b/DeviceDetector.NET.NetCore.sln
@@ -1,0 +1,41 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27130.2027
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{F638B5CE-3208-4D42-85C4-6E9F0F545DB0}"
+	ProjectSection(SolutionItems) = preProject
+		.gitattributes = .gitattributes
+		.gitignore = .gitignore
+		DeviceDetector.NET.nuspec = DeviceDetector.NET.nuspec
+		DeviceDetector.NET.targets = DeviceDetector.NET.targets
+		LICENSE = LICENSE
+		README.md = README.md
+	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DeviceDetector.NET.NetCore", "src\DeviceDetector.NET\DeviceDetector.NET.NetCore.csproj", "{40974982-3F3A-4A14-8B57-239D864B2967}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DeviceDetector.NET.NetCore.Tests", "test\DeviceDetector.NET.Tests\DeviceDetector.NET.NetCore.Tests.csproj", "{3311EC91-7831-4B70-82D1-34C7E6F882F6}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{40974982-3F3A-4A14-8B57-239D864B2967}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{40974982-3F3A-4A14-8B57-239D864B2967}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{40974982-3F3A-4A14-8B57-239D864B2967}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{40974982-3F3A-4A14-8B57-239D864B2967}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3311EC91-7831-4B70-82D1-34C7E6F882F6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3311EC91-7831-4B70-82D1-34C7E6F882F6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3311EC91-7831-4B70-82D1-34C7E6F882F6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3311EC91-7831-4B70-82D1-34C7E6F882F6}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {1BA919C2-27E1-4BC1-96B4-EFF42DAA4819}
+	EndGlobalSection
+EndGlobal

--- a/src/DeviceDetector.NET/DeviceDetector.NET.NetCore.csproj
+++ b/src/DeviceDetector.NET/DeviceDetector.NET.NetCore.csproj
@@ -1,0 +1,65 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <PackageId>DeviceDetectorNET</PackageId>
+    <Version>3.9.2</Version>
+    <AssemblyVersion>3.9.2.1</AssemblyVersion>
+    <FileVersion>3.9.2.1</FileVersion>
+    <Description>The Universal Device Detection library that parses User Agents and detects devices (desktop, tablet, mobile, tv, cars, console, etc.), clients (browsers, feed readers, media players, PIMs, ...), operating systems, brands and models.</Description>
+    <Authors>TotPeRo</Authors>
+    <Company>TotPeRo</Company>
+    <Product>DeviceDetectorNET</Product>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Remove="regexes\bots.yml" />
+    <None Remove="regexes\client\browsers.yml" />
+    <None Remove="regexes\client\browser_engine.yml" />
+    <None Remove="regexes\client\feed_readers.yml" />
+    <None Remove="regexes\client\libraries.yml" />
+    <None Remove="regexes\client\mediaplayers.yml" />
+    <None Remove="regexes\client\mobile_apps.yml" />
+    <None Remove="regexes\client\pim.yml" />
+    <None Remove="regexes\device\cameras.yml" />
+    <None Remove="regexes\device\car_browsers.yml" />
+    <None Remove="regexes\device\consoles.yml" />
+    <None Remove="regexes\device\mobiles.yml" />
+    <None Remove="regexes\device\portable_media_player.yml" />
+    <None Remove="regexes\device\televisions.yml" />
+    <None Remove="regexes\oss.yml" />
+    <None Remove="regexes\vendorfragments.yml" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="regexes\bots.yml" />
+    <EmbeddedResource Include="regexes\client\browsers.yml" />
+    <EmbeddedResource Include="regexes\client\browser_engine.yml" />
+    <EmbeddedResource Include="regexes\client\feed_readers.yml" />
+    <EmbeddedResource Include="regexes\client\libraries.yml" />
+    <EmbeddedResource Include="regexes\client\mediaplayers.yml" />
+    <EmbeddedResource Include="regexes\client\mobile_apps.yml" />
+    <EmbeddedResource Include="regexes\client\pim.yml" />
+    <EmbeddedResource Include="regexes\device\cameras.yml" />
+    <EmbeddedResource Include="regexes\device\car_browsers.yml" />
+    <EmbeddedResource Include="regexes\device\consoles.yml" />
+    <EmbeddedResource Include="regexes\device\mobiles.yml" />
+    <EmbeddedResource Include="regexes\device\portable_media_player.yml" />
+    <EmbeddedResource Include="regexes\device\televisions.yml" />
+    <EmbeddedResource Include="regexes\oss.yml" />
+    <EmbeddedResource Include="regexes\vendorfragments.yml" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="YamlDotNet.NetCore" Version="1.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/DeviceDetector.NET/DeviceDetector.NET.csproj
+++ b/src/DeviceDetector.NET/DeviceDetector.NET.csproj
@@ -31,6 +31,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup>
+    <!-- Needed due to old project and new project in same directory: https://github.com/NuGet/Home/issues/5126 -->
+    <BaseIntermediateOutputPath>obj_netfx\</BaseIntermediateOutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <PropertyGroup>
@@ -122,54 +126,22 @@
   <ItemGroup>
     <None Include="DeviceDetector.NET.snk" />
     <None Include="packages.config" />
-    <None Include="regexes\bots.yml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="regexes\client\browsers.yml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="regexes\client\browser_engine.yml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="regexes\client\feed_readers.yml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="regexes\client\libraries.yml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="regexes\client\mediaplayers.yml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="regexes\client\mobile_apps.yml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="regexes\client\pim.yml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="regexes\device\cameras.yml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="regexes\device\car_browsers.yml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="regexes\device\consoles.yml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="regexes\device\mobiles.yml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="regexes\device\portable_media_player.yml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="regexes\device\televisions.yml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="regexes\oss.yml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="regexes\vendorfragments.yml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
+    <EmbeddedResource Include="regexes\bots.yml" />
+    <EmbeddedResource Include="regexes\client\browsers.yml" />
+    <EmbeddedResource Include="regexes\client\browser_engine.yml" />
+    <EmbeddedResource Include="regexes\client\feed_readers.yml" />
+    <EmbeddedResource Include="regexes\client\libraries.yml" />
+    <EmbeddedResource Include="regexes\client\mediaplayers.yml" />
+    <EmbeddedResource Include="regexes\client\mobile_apps.yml" />
+    <EmbeddedResource Include="regexes\client\pim.yml" />
+    <EmbeddedResource Include="regexes\device\cameras.yml" />
+    <EmbeddedResource Include="regexes\device\car_browsers.yml" />
+    <EmbeddedResource Include="regexes\device\consoles.yml" />
+    <EmbeddedResource Include="regexes\device\mobiles.yml" />
+    <EmbeddedResource Include="regexes\device\portable_media_player.yml" />
+    <EmbeddedResource Include="regexes\device\televisions.yml" />
+    <EmbeddedResource Include="regexes\oss.yml" />
+    <EmbeddedResource Include="regexes\vendorfragments.yml" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/DeviceDetector.NET/Parser/ParserAbstract.cs
+++ b/src/DeviceDetector.NET/Parser/ParserAbstract.cs
@@ -153,7 +153,7 @@ namespace DeviceDetectorNET.Parser
 
             var assembly = Assembly.GetAssembly(GetType());
 
-#if NETCOREAPP2_0
+#if NETCOREAPP
             var resourcePrefix = assembly.GetName().Name;
 #else
             var resourcePrefix = typeof(DeviceDetector).Namespace;

--- a/src/DeviceDetector.NET/Yaml/IParser.cs
+++ b/src/DeviceDetector.NET/Yaml/IParser.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.IO;
 
 namespace DeviceDetectorNET.Yaml
 {
@@ -6,5 +7,7 @@ namespace DeviceDetectorNET.Yaml
         where T : IEnumerable //IParseLibrary
     {
         T ParseFile(string file);
+
+        T ParseStream(Stream stream);
     }
 }

--- a/src/DeviceDetector.NET/Yaml/YamlParser.cs
+++ b/src/DeviceDetector.NET/Yaml/YamlParser.cs
@@ -13,18 +13,31 @@ namespace DeviceDetectorNET.Yaml
         {
             using (var r = new StreamReader(file))
             {
-                var deserializer = new DeserializerBuilder().Build();
-                var parser = new YamlDotNet.Core.Parser(r);
+                return Parse(r);
+            }
+        }
 
-                // Consume the stream start event "manually"
-                parser.Expect<StreamStart>();
+        private static T Parse(StreamReader r)
+        {
+            var deserializer = new DeserializerBuilder().Build();
+            var parser = new YamlDotNet.Core.Parser(r);
 
-                while (parser.Accept<DocumentStart>())
-                    // Deserialize the document
-                {
-                    return deserializer.Deserialize<T>(parser);
-                }
-                return null;
+            // Consume the stream start event "manually"
+            parser.Expect<StreamStart>();
+
+            while (parser.Accept<DocumentStart>())
+                // Deserialize the document
+            {
+                return deserializer.Deserialize<T>(parser);
+            }
+            return null;
+        }
+
+        public T ParseStream(Stream stream)
+        {
+            using (var r = new StreamReader(stream))
+            {
+                return Parse(r);
             }
         }
     }

--- a/test/DeviceDetector.NET.Tests/DeviceDetector.NET.NetCore.Tests.csproj
+++ b/test/DeviceDetector.NET.Tests/DeviceDetector.NET.NetCore.Tests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+
+    <Authors>TotPeRo</Authors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="4.19.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\DeviceDetector.NET\DeviceDetector.NET.NetCore.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+
+</Project>

--- a/test/DeviceDetector.NET.Tests/DeviceDetector.NET.Tests.csproj
+++ b/test/DeviceDetector.NET.Tests/DeviceDetector.NET.Tests.csproj
@@ -37,6 +37,10 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <!-- Needed due to old project and new project in same directory: https://github.com/NuGet/Home/issues/5126 -->
+    <BaseIntermediateOutputPath>obj_netfx\</BaseIntermediateOutputPath>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="FluentAssertions, Version=4.19.4.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\FluentAssertions.4.19.4\lib\net45\FluentAssertions.dll</HintPath>

--- a/test/DeviceDetector.NET.Tests/Utils.cs
+++ b/test/DeviceDetector.NET.Tests/Utils.cs
@@ -8,7 +8,7 @@ namespace DeviceDetectorNET.Tests
         {
             var directoryInfo = Directory.GetParent(Directory.GetCurrentDirectory()).Parent;
 
-#if NETCOREAPP2_0
+#if NETCOREAPP
             directoryInfo = directoryInfo.Parent;
 #endif
 

--- a/test/DeviceDetector.NET.Tests/Utils.cs
+++ b/test/DeviceDetector.NET.Tests/Utils.cs
@@ -7,6 +7,11 @@ namespace DeviceDetectorNET.Tests
         public static string CurrentDirectory()
         {
             var directoryInfo = Directory.GetParent(Directory.GetCurrentDirectory()).Parent;
+
+#if NETCOREAPP2_0
+            directoryInfo = directoryInfo.Parent;
+#endif
+
             return directoryInfo?.FullName ?? "";
         }
     }


### PR DESCRIPTION
This is my attempt at making the project compatible for .NET Core.

1. Created separate Solution & Project Files for .NET Core
2. Made changes to **DeviceDetectorNET.Tests.Utils** to handle output path in .NET Core
3. Specified a **BaseIntermediateOutputPath** path for .NET Framework 4.5 projects. If this was not done, the intermediate outputs would overwrite each other and if you tried to compile the .NET Framework 4.5 solution, you would get the following error:-

```
Your project is not referencing the ".NETFramework,Version=4.5" framework. Add a reference to 
".NETFramework,Version=4.5" in the "frameworks" section of your project.json, and then re-run NuGet 
restore.
```

This solution was suggested [here](https://stackoverflow.com/a/45947426/1118239).

4. Created a separate nuspec file for .NET Core. The YAMLs inside **regexes** folder were not added to the project that installed the .NET Core Nuget Reference. I played around with the solution mentioned [here](https://github.com/NuGet/Home/issues/6548) which asks to put the files inside **contentFiles**. But, this never worked, the files were never even included inside the nuget package. So, I gave up on this approach and did the following.
5. Added a **ParseStream** method in **IParser** and implemented it in **YamlParser**.
6. Made changes to **ParserAbstract** to read the YAML files from the assembly manifest resource section.
7. Marked the YAMLs as **EmbeddedResource** in both .NET Framework 4.5 and .NET Core project

Steps 4-7 are perhaps the most radical changes to your code. But, I could not find a way around it. Unit Tests are working fine in both the solutions.
