### PR TITLE
Added DeviceDetectorSettings.cs in order to allow users to specify in…

### DIFF
--- a/src/DeviceDetector.NET/DeviceDetector.NET.csproj
+++ b/src/DeviceDetector.NET/DeviceDetector.NET.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Class\Os.cs" />
     <Compile Include="Class\Producer.cs" />
     <Compile Include="DeviceDetector.cs" />
+    <Compile Include="DeviceDetectorSettings.cs" />
     <Compile Include="IEnumerableExtensions.cs" />
     <Compile Include="Parser\BotParser.cs" />
     <Compile Include="Parser\Client\BrowserParser.cs" />

--- a/src/DeviceDetector.NET/DeviceDetectorSettings.cs
+++ b/src/DeviceDetector.NET/DeviceDetectorSettings.cs
@@ -1,0 +1,7 @@
+﻿namespace DeviceDetectorNET
+{
+    public class DeviceDetectorSettings
+    {
+        public static string RegexesDirectory { get; set; }
+    }
+}

--- a/src/DeviceDetector.NET/Parser/ParserAbstract.cs
+++ b/src/DeviceDetector.NET/Parser/ParserAbstract.cs
@@ -163,6 +163,9 @@ namespace DeviceDetectorNET.Parser
         /// <returns></returns>
         protected string GetRegexesDirectory()
         {
+            if (!string.IsNullOrWhiteSpace(DeviceDetectorSettings.RegexesDirectory))
+                return DeviceDetectorSettings.RegexesDirectory;
+
             return "";
             //return "regexes/";
         }


### PR DESCRIPTION
Added DeviceDetectorSettings.cs in order to allow users to specify in web-projects custom path to regexes directory. It is much better solution than bringing System.Web dependency like done here https://github.com/totpero/DeviceDetector.NET/pull/11/commits/868e2444bf2a5553d2f014fa15c81930716e1afd