### PR TITLE
Add persistent caching to Parse results to improve performance

### DIFF
--- a/DeviceDetector.NET.Tests/DeviceDetectorTest.cs
+++ b/DeviceDetector.NET.Tests/DeviceDetectorTest.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using FluentAssertions;
 using DeviceDetectorNET.Cache;
@@ -18,11 +17,11 @@ namespace DeviceDetectorNET.Tests
     [Trait("Category", "DeviceDetector")]
     public class DeviceDetectorTest
     {
-        public DeviceDetectorTest()
-        {
-            // cache results data for 1 year
-            DeviceDetector.ExpirationForDeviceDetectorResults = TimeSpan.FromDays(365);
-        }
+        // Uncomment below to test the cache during the xUnit tests
+        // public DeviceDetectorTest()
+        //{
+        //    DeviceDetectorSettings.ParseCacheDBExpiration = TimeSpan.FromDays(365);
+        //}
 
         [Fact]
         public void TestAddClientParserInvalid()
@@ -401,6 +400,19 @@ namespace DeviceDetectorNET.Tests
                 dd.IsMobile().Should().Be(item.Item3);
                 dd.IsDesktop().Should().Be(item.Item4);
             }
+        }
+        [Fact]
+        public void TestLRUCache()
+        {
+            var dd = LRUCachedDeviceDetector.GetDeviceDetector("Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0)");
+            dd.IsParsed().Should().BeTrue();
+            var os = dd.GetOs();
+            os.Success.Should().BeTrue();
+            os = dd.GetOs();
+            os.Match.Name.Should().BeEquivalentTo("Windows");
+            os.Match.ShortName.Should().BeEquivalentTo("WIN");
+            os.Match.Version.Should().BeEquivalentTo("7");
+            os.Match.Platform.Should().BeEquivalentTo(PlatformType.X64);
         }
 
         [Fact]

--- a/DeviceDetector.NET.Tests/DeviceDetectorTest.cs
+++ b/DeviceDetector.NET.Tests/DeviceDetectorTest.cs
@@ -18,6 +18,12 @@ namespace DeviceDetectorNET.Tests
     [Trait("Category", "DeviceDetector")]
     public class DeviceDetectorTest
     {
+        public DeviceDetectorTest()
+        {
+            // cache results data for 1 year
+            DeviceDetector.ExpirationForDeviceDetectorResults = TimeSpan.FromDays(365);
+        }
+
         [Fact]
         public void TestAddClientParserInvalid()
         {

--- a/DeviceDetector.NET/Cache/GenericLRUCache.cs
+++ b/DeviceDetector.NET/Cache/GenericLRUCache.cs
@@ -1,0 +1,169 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading;
+
+namespace DeviceDetectorNET.Cache
+{
+    /// <summary>
+    /// See https://gist.github.com/eladmarg/8d4a7f7a43a36c35d488e99475a101d9
+    /// </summary>
+    /// <typeparam name="TV"></typeparam>
+    /// <typeparam name="TU"></typeparam>
+    public class GenericLRUCache<TV, TU> where TU : class
+        {
+            private readonly int CacheMaxSize;
+            private readonly int CleanSize;
+            private readonly TimeSpan MaxDuration;
+
+            private readonly ConcurrentDictionary<TV, CacheDataObject<TU>> _cache = new ConcurrentDictionary<TV, CacheDataObject<TU>>();
+
+            public GenericLRUCache(int maxSize = 50000, int cleanPercentage = 30, TimeSpan maxDuration = default(TimeSpan))
+            {
+                CacheMaxSize = maxSize;
+                CleanSize = (int)Math.Max(CacheMaxSize * (1.0 * cleanPercentage / 100), 1000);
+                if (maxDuration == default(TimeSpan))
+                {
+                    MaxDuration = TimeSpan.FromDays(1);
+                }
+                else
+                {
+                    MaxDuration = maxDuration;
+                }
+            }
+
+            private static readonly object _lockObject = new object();
+            private static bool IsCleaning = false;
+
+            public bool AddToCache(TV cacheKey, TU value)
+            {
+                var cachedResult = new CacheDataObject<TU>
+                {
+                    Usage = 1,
+                    Value = value,
+                    Timestamp = DateTime.UtcNow
+                };
+
+                _cache.AddOrUpdate(cacheKey, cachedResult, (_, __) => cachedResult);
+                if (_cache.Count > 0 && _cache.Count > CacheMaxSize && !IsCleaning)
+                {
+
+                    lock (_lockObject)
+                    {
+                        if (IsCleaning)
+                            return true;
+
+                        try
+                        {
+                            IsCleaning = true;
+                            var cacheArray = _cache.ToArray();
+                            if (cacheArray.Length > 0)
+                            {
+                                var itemsToSkip = CacheMaxSize - CleanSize;
+                                if (itemsToSkip > 10)
+                                {
+                                    var items = cacheArray.OrderByDescending(x => x.Value.Usage)
+                                          .ThenBy(x => x.Value.Timestamp)
+                                          .Skip(itemsToSkip);
+
+                                    if (items.Any())
+                                    {
+                                        foreach (var source in items)
+                                        {
+                                            if (source.Key == null || cacheKey == null)
+                                                continue;
+
+                                            if (EqualityComparer<TV>.Default.Equals(source.Key, cacheKey))
+                                                continue; // we don't want to remove the one we just added
+
+                                            CacheDataObject<TU> ignored;
+                                            _cache.TryRemove(source.Key, out ignored);
+                                        }
+                                    }
+                                }
+
+
+                            }
+
+                        }
+                        finally
+                        {
+                            IsCleaning = false;
+                        }
+                    }
+
+                }
+                return true;
+            }
+
+            public TU GetFromCache(TV cacheKey, bool increment = true)
+            {
+                CacheDataObject<TU> value;
+                if (_cache.TryGetValue(cacheKey, out value) && (MaxDuration == TimeSpan.MaxValue || (DateTime.UtcNow - value.Timestamp) <= MaxDuration))
+                {
+                    if (increment)
+                    {
+                        Interlocked.Increment(ref value.Usage);
+                    }
+                    return value.Value;
+                }
+                return null;
+            }
+
+            public TU GetOrAdd(TV cacheKey, Func<TU> aquire, bool increment = true)
+            {
+                CacheDataObject<TU> value;
+                if (_cache.TryGetValue(cacheKey, out value) && (MaxDuration == TimeSpan.MaxValue || (DateTime.UtcNow - value.Timestamp) <= MaxDuration))
+                {
+                    if (increment)
+                    {
+                        Interlocked.Increment(ref value.Usage);
+                    }
+                    return value.Value;
+                }
+                TU val = aquire();
+                if (val != default(TU))
+                {
+                    AddToCache(cacheKey, val);
+                }
+
+                return val;
+            }
+
+            public bool TryGetValue(TV cacheKey, out TU val, bool increment = true)
+            {
+                CacheDataObject<TU> value;
+                if (_cache.TryGetValue(cacheKey, out value) && (MaxDuration == TimeSpan.MaxValue || (DateTime.UtcNow - value.Timestamp) <= MaxDuration))
+                {
+                    if (increment)
+                    {
+                        Interlocked.Increment(ref value.Usage);
+                    }
+                    val = value.Value;
+                    return true;
+                }
+                val = default(TU);
+                return false;
+            }
+
+            public void Remove(TV cacheKey)
+            {
+                CacheDataObject<TU> value;
+                _cache.TryRemove(cacheKey, out value);
+            }
+
+            public bool IsExistInCache(TV cacheKey)
+            {
+                return (_cache.ContainsKey(cacheKey));
+            }
+
+
+            private class CacheDataObject<T> where T : class
+            {
+                public DateTime Timestamp;
+                public int Usage;
+                public T Value;
+            }
+        }
+    }

--- a/DeviceDetector.NET/Cache/LRUCachedDeviceDetector.cs
+++ b/DeviceDetector.NET/Cache/LRUCachedDeviceDetector.cs
@@ -1,0 +1,41 @@
+﻿using System;
+
+namespace DeviceDetectorNET.Cache
+{
+    public static class LRUCachedDeviceDetector
+    {
+        private static readonly DictionaryCache deviceCache;
+        private static readonly GenericLRUCache<string, DeviceDetector> lruDeviceDetector;
+
+        static LRUCachedDeviceDetector()
+        {
+            deviceCache = new DictionaryCache();
+
+            lruDeviceDetector = new GenericLRUCache<string, DeviceDetector>(maxSize: DeviceDetectorSettings.LRUCacheMaxSize,
+                cleanPercentage: DeviceDetectorSettings.LRUCacheCleanPercentage,
+                maxDuration: DeviceDetectorSettings.LRUCacheMaxDuration);
+        }
+
+        /// <summary>
+        /// LRU cached version of GetDeviceDetector
+        /// </summary>
+        /// <param name="userAgent">used as the key for the cache lookup.
+        /// Note that this does not handle situations where SetVersionTruncation is used because Parse will operate differently based on Version Truncation, which
+        /// is a static variable.</param>
+        /// <returns></returns>
+        public static DeviceDetector GetDeviceDetector(string userAgent)
+        {
+            if (string.IsNullOrEmpty(userAgent))
+                return null;
+
+            if (!lruDeviceDetector.TryGetValue(userAgent, out var dd))
+            {
+                dd = new DeviceDetector(userAgent);
+                dd.SetCache(deviceCache);
+                dd.Parse();
+                lruDeviceDetector.AddToCache(userAgent, dd);
+            }
+            return dd;
+        }
+    }
+}

--- a/DeviceDetector.NET/Class/Producer.cs
+++ b/DeviceDetector.NET/Class/Producer.cs
@@ -1,11 +1,18 @@
+using System;
+using System.Runtime.Serialization;
 using YamlDotNet.Serialization;
 
 namespace DeviceDetectorNET.Class
 {
+    [Serializable]
+    [DataContract]
     public class Producer
     {
+        [DataMember]
         [YamlMember(Alias = "name")]
         public string Name { get; set; }
+
+        [DataMember]
         [YamlMember(Alias = "url")]
         public string Url { get; set; }
     }

--- a/DeviceDetector.NET/DeviceDetector.NET.csproj
+++ b/DeviceDetector.NET/DeviceDetector.NET.csproj
@@ -27,6 +27,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="MonkeyCache" Version="1.3.0" />
+    <PackageReference Include="MonkeyCache.LiteDB" Version="1.3.0" />
     <PackageReference Include="YamlDotNet" Version="8.1.2" />
   </ItemGroup>
 

--- a/DeviceDetector.NET/DeviceDetector.NET.csproj
+++ b/DeviceDetector.NET/DeviceDetector.NET.csproj
@@ -27,8 +27,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MonkeyCache" Version="1.3.0" />
-    <PackageReference Include="MonkeyCache.LiteDB" Version="1.3.0" />
+    <PackageReference Include="LiteDB" Version="4.1.4" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="YamlDotNet" Version="8.1.2" />
   </ItemGroup>
 

--- a/DeviceDetector.NET/DeviceDetectorSettings.cs
+++ b/DeviceDetector.NET/DeviceDetectorSettings.cs
@@ -1,4 +1,6 @@
-﻿namespace DeviceDetectorNET
+﻿using System;
+
+namespace DeviceDetectorNET
 {
     /// <summary>
     /// Global DeviceDetector settings
@@ -8,6 +10,12 @@
         static DeviceDetectorSettings()
         {
             RegexesDirectory = string.Empty;
+            ParseCacheDBFilename = null;
+            ParseCacheDBDirectory = string.Empty;
+            ParseCacheDBExpiration = TimeSpan.Zero;
+            LRUCacheMaxSize = 10_000;
+            LRUCacheMaxDuration = TimeSpan.FromMinutes(10);
+            LRUCacheCleanPercentage = 30;
         }
 
         /// <summary>
@@ -16,5 +24,38 @@
         /// Exemple: C:\YamlRegexsFiles\
         /// </summary>
         public static string RegexesDirectory { get; set; }
+
+        /// <summary>
+        /// Default Parse cache database filename. Defaults to DeviceDetectorNET.db
+        /// </summary>
+        public static string ParseCacheDBFilename { get; set; }
+
+        /// <summary>
+        /// Default Parse cache database directory. Defaults to string.Empty, which is the application's directory
+        /// </summary>
+        public static string ParseCacheDBDirectory { get; set; }
+
+        /// <summary>
+        /// To improve performance, we can cache the parsed DeviceDetector results.
+        /// ParseCacheDBExpiration defaults to TimeSpan.Zero, which disables the cache
+        /// One might consider setting this to a value like TimeSpan.FromDays(365) to improve performance
+        /// </summary>
+        public static TimeSpan ParseCacheDBExpiration { get; set; }
+
+        /// <summary>
+        /// Default maximum size for least recently used (LRU) in-memory cache database (defaults to 10,000 records)
+        /// </summary>
+        public static int LRUCacheMaxSize { get; set; }
+
+        /// <summary>
+        /// When the LRU cache is full, purge this percentage of the cache (defaults to 30%)
+        /// </summary>
+        public static int LRUCacheCleanPercentage { get; set; }
+
+        /// <summary>
+        /// Default maximum cache duration for LRU in-memory cache database (default to 10 minutes)
+        /// </summary>
+        public static TimeSpan LRUCacheMaxDuration { get; set; }
+
     }
 }

--- a/DeviceDetector.NET/Results/BotMatchResult.cs
+++ b/DeviceDetector.NET/Results/BotMatchResult.cs
@@ -1,13 +1,20 @@
 using DeviceDetectorNET.Class;
 using System;
+using System.Runtime.Serialization;
 
 namespace DeviceDetectorNET.Results
 {
+    [Serializable]
+    [DataContract]
     public class BotMatchResult: IBotMatchResult
     {
+        [DataMember]
         public string Name { get; set; }
+        [DataMember]
         public string Category { get; set; }
+        [DataMember]
         public string Url { get; set; }
+        [DataMember]
         public Producer Producer { get; set; }
 
         public override string ToString() =>

--- a/DeviceDetector.NET/Results/Client/BrowserMatchResult.cs
+++ b/DeviceDetector.NET/Results/Client/BrowserMatchResult.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Runtime.Serialization;
 
 namespace DeviceDetectorNET.Results.Client
 {
+    [Serializable]
+    [DataContract]
     public class BrowserMatchResult : ClientMatchResult
     {
+        [DataMember]
         public string ShortName { get; set; }
+        [DataMember]
         public string Engine { get; set; }
+        [DataMember]
         public string EngineVersion { get; set; }
 
         public override string ToString() => 

--- a/DeviceDetector.NET/Results/Client/ClientMatchResult.cs
+++ b/DeviceDetector.NET/Results/Client/ClientMatchResult.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Runtime.Serialization;
 
 namespace DeviceDetectorNET.Results.Client
 {
+    [Serializable]
+    [DataContract]
     public class ClientMatchResult:IClientMatchResult
     {
+        [DataMember]
         public virtual string Type { get; set; }
+        [DataMember]
         public virtual string Name { get; set; }
+        [DataMember]
         public string Version { get; set; }
 
         public override string ToString() =>

--- a/DeviceDetector.NET/Results/Client/UnknownClientMatchResult.cs
+++ b/DeviceDetector.NET/Results/Client/UnknownClientMatchResult.cs
@@ -1,8 +1,16 @@
+using System;
+using System.Runtime.Serialization;
+
 namespace DeviceDetectorNET.Results.Client
 {
-    class UnknownClientMatchResult: ClientMatchResult
+    [Serializable]
+    [DataContract]
+    class UnknownClientMatchResult : ClientMatchResult
     {
+        [DataMember]
+
         public override string Type { get => "UNK"; }
+        [DataMember]
         public override string Name { get => "UNK"; }
     }
 }

--- a/DeviceDetector.NET/Results/Device/DeviceMatchResult.cs
+++ b/DeviceDetector.NET/Results/Device/DeviceMatchResult.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Runtime.Serialization;
 
 namespace DeviceDetectorNET.Results.Device
 {
+    [Serializable]
+    [DataContract]
     public class DeviceMatchResult : IDeviceMatchResult
     {
+        [DataMember]
         public string Name { get; set; }
+        [DataMember]
         public string Brand { get; set; }
+        [DataMember]
         public int? Type { get; set; }
 
         public override string ToString() =>

--- a/DeviceDetector.NET/Results/DeviceDetectorResult.cs
+++ b/DeviceDetector.NET/Results/DeviceDetectorResult.cs
@@ -1,8 +1,11 @@
 using DeviceDetectorNET.Results.Client;
 using System;
+using System.Runtime.Serialization;
 
 namespace DeviceDetectorNET.Results
 {
+    [Serializable]
+    [DataContract]
     public class DeviceDetectorResult
     {
         public DeviceDetectorResult()
@@ -10,14 +13,23 @@ namespace DeviceDetectorNET.Results
             OsFamily = "Unknown";
             BrowserFamily = "Unknown";
         }
+        [DataMember]
         public string UserAgent { get; set; }
+        [DataMember]
         public BotMatchResult Bot { get; set; }
+        [DataMember]
         public OsMatchResult Os { get; set; }
+        [DataMember]
         public ClientMatchResult Client { get; set; }
+        [DataMember]
         public string DeviceType { get; set; }
+        [DataMember]
         public string DeviceBrand { get; set; }
+        [DataMember]
         public string DeviceModel { get; set; }
+        [DataMember]
         public string OsFamily { get; set; }
+        [DataMember]
         public string BrowserFamily { get; set; }
 
         public override string ToString() =>

--- a/DeviceDetector.NET/Results/OsMatchResult.cs
+++ b/DeviceDetector.NET/Results/OsMatchResult.cs
@@ -1,12 +1,19 @@
 using System;
+using System.Runtime.Serialization;
 
 namespace DeviceDetectorNET.Results
 {
+    [Serializable]
+    [DataContract]
     public class OsMatchResult:IMatchResult
     {
+        [DataMember]
         public virtual string Name { get; set; }
+        [DataMember]
         public virtual string ShortName { get; set; }
+        [DataMember]
         public string Version { get; set; }
+        [DataMember]
         public string Platform { get; set; }
 
         public override string ToString() =>

--- a/DeviceDetector.NET/Results/ParseResult.cs
+++ b/DeviceDetector.NET/Results/ParseResult.cs
@@ -1,8 +1,12 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Serialization;
 
 namespace DeviceDetectorNET.Results
 {
+    [Serializable]
+    [DataContract]
     public class ParseResult<TMatch>
         where TMatch : class
     {
@@ -19,8 +23,11 @@ namespace DeviceDetectorNET.Results
             Success = success;
         }
 
+
+        [DataMember]
         public bool Success { get; private set; }
         public TMatch Match => Success ? Matches.FirstOrDefault() : null;
+        [DataMember] 
         public List<TMatch> Matches { get; set; }
 
         public ParseResult<TMatch> Add(TMatch match)

--- a/DeviceDetector.NET/Results/UnknownOsMatchResult.cs
+++ b/DeviceDetector.NET/Results/UnknownOsMatchResult.cs
@@ -1,8 +1,16 @@
+using System;
+using System.Runtime.Serialization;
+
 namespace DeviceDetectorNET.Results
 {
-    class UnknownOsMatchResult: OsMatchResult
+    [Serializable]
+    [DataContract]
+
+    class UnknownOsMatchResult : OsMatchResult
     {
+        [DataMember]
         public override string Name { get => "UNK"; }
+        [DataMember]
         public override string ShortName { get => "UNK"; }
     }
 }

--- a/DeviceDetector.NET/Results/VendorFragmentResult.cs
+++ b/DeviceDetector.NET/Results/VendorFragmentResult.cs
@@ -1,12 +1,18 @@
 using DeviceDetectorNET.Results.Device;
 using System;
+using System.Runtime.Serialization;
 
 namespace DeviceDetectorNET.Results
 {
+    [Serializable]
+    [DataContract]
     public class VendorFragmentResult : IDeviceMatchResult
     {
+        [DataMember]
         public string Name { get; set; }
+        [DataMember]
         public string Brand { get; set; }
+        [DataMember]
         public int? Type { get => throw new System.NotSupportedException(); set => throw new System.NotSupportedException(); }
 
         public override string ToString() =>


### PR DESCRIPTION
Added use of MonkeyCache.LiteDB to cache the results of Parse calls.

Improves performance of already Parsed user agent strings by approximately 50x. (In benchmarking the unit tests, results improve from 12 minutes for the first run, to 16 seconds for the second run.)

By default, the new caching is **disabled** (although I enabled it for the unit tests).

To use the new caching, set the cache expiration as follows:

// cache results data for 1 year
`DeviceDetector.ExpirationForDeviceDetectorResults = TimeSpan.FromDays(365);
`

