### PR TITLE
Making MSRegexCompiledEngine properly use concurrent dictionary

### DIFF
--- a/DeviceDetector.NET/RegexEngine/MSRegexCompiledEngine.cs
+++ b/DeviceDetector.NET/RegexEngine/MSRegexCompiledEngine.cs
@@ -15,7 +15,7 @@ namespace DeviceDetectorNET.RegexEngine
         
         private Regex GetRegex(string pattern)
         {
-            return _staticRegExCache.Value.GetOrAdd(pattern, new Regex(pattern, RegexOptions.IgnoreCase | RegexOptions.Compiled));
+            return _staticRegExCache.Value.GetOrAdd(pattern, (regexPattern) => new Regex(regexPattern, RegexOptions.IgnoreCase | RegexOptions.Compiled));
         }
         
         public bool Match(string input, string pattern)
@@ -39,7 +39,7 @@ namespace DeviceDetectorNET.RegexEngine
                 {
                     if (!match.Value.Equals(group.Value))
                     {
-                       yield return group.Value;
+                        yield return group.Value;
                     }
                 }
             }


### PR DESCRIPTION
this currently was instantiating the regex object every time this was called effectively making the cache useless

I ran some benchmarks after my changes as you can see below.
These results are parsing 100 different user agent.
I also preloaded all of the regex before these tests run to ensure consistent results


![image](https://user-images.githubusercontent.com/37006998/196573740-583b98c6-ef65-484c-bce5-7c1df09b988e.png)


And here is the benchmark code
```cs
 public class Benchy
    {
        private List<string> userAgents = new List<string>();
        [GlobalSetup]
        public void Setup()
        {
            userAgents = File.ReadAllLines(@"C:\temp\useragents.txt").ToList();
            
            
            foreach (var device in userAgents.Take(20))
            {
                new DeviceDetector(device).Parse();
                new DeviceDetectorV2(device).Parse();
            }
            userAgents = File.ReadAllLines(@"C:\temp\useragents.txt").Skip(20).Take(100).ToList();
        }

        [Benchmark]
        public void OldWay()
        {
            foreach (var device in userAgents)
                new DeviceDetector(device).Parse();
        }

        [Benchmark]
        public void Refactored()
        {
            foreach (var device in userAgents)
                new DeviceDetectorV2(device).Parse();
        }
    }
```