### PR TITLE
Remove Semver library as it is not being used and out-of-date

### DIFF
--- a/DeviceDetector.NET/DeviceDetector.NET.csproj
+++ b/DeviceDetector.NET/DeviceDetector.NET.csproj
@@ -29,7 +29,6 @@
   <ItemGroup>
     <PackageReference Include="LiteDB" Version="5.0.13" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-    <PackageReference Include="semver" Version="2.0.6" />
     <PackageReference Include="YamlDotNet" Version="11.2.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
   </ItemGroup>

--- a/DeviceDetector.NET/Parser/Client/BrowserParser.cs
+++ b/DeviceDetector.NET/Parser/Client/BrowserParser.cs
@@ -6,7 +6,6 @@ using DeviceDetectorNET.Parser.Client.Browser;
 using DeviceDetectorNET.Parser.Client.Browser.Engine;
 using DeviceDetectorNET.Results;
 using DeviceDetectorNET.Results.Client;
-using Semver;
 
 namespace DeviceDetectorNET.Parser.Client
 {


### PR DESCRIPTION
A small pull request that removes the Semver library. It seems to not be used in the code and the current version in the `.csproj` of `2.0.3` pulls in the `NetStandard.library = 1.6.1`, which itself contains a bunch of dependencies of which some contain vulnerabilities. This has been solved in `Semver >= 2.1.0` but as the library does not seem to be used I removed the reference to it entirely.

DeviceDetector.Net is a great library btw, thanks for maintaining it :) 