### PR TITLE
Drop NET 5 and 7 support, upgrade dependencies

### DIFF
--- a/DeviceDetector.NET.RegexEngine.PCRE/DeviceDetector.NET.RegexEngine.PCRE.csproj
+++ b/DeviceDetector.NET.RegexEngine.PCRE/DeviceDetector.NET.RegexEngine.PCRE.csproj
@@ -6,7 +6,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="PCRE.NET" Version="1.0.0" />
+		<PackageReference Include="PCRE.NET" Version="1.1.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/DeviceDetector.NET.Tests/DeviceDetector.NET.Tests.csproj
+++ b/DeviceDetector.NET.Tests/DeviceDetector.NET.Tests.csproj
@@ -11,8 +11,8 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/DeviceDetector.NET/DeviceDetector.NET.csproj
+++ b/DeviceDetector.NET/DeviceDetector.NET.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;Net462;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462;net6.0;net8.0</TargetFrameworks>
     <RootNamespace>DeviceDetectorNET</RootNamespace>
     <Version>6.3.3</Version>
     <Authors>totpero</Authors>
@@ -31,18 +31,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="LiteDB" Version="5.0.20" />
+    <PackageReference Include="LiteDB" Version="5.0.21" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="YamlDotNet" Version="15.1.6" />
-
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" Condition="'$(TargetFramework)' == 'net7.0'" />
-
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" Condition="'$(TargetFramework)' == 'net5.0'" />
-
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" Condition="'$(TargetFramework)' == 'net462'" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+    <PackageReference Include="YamlDotNet" Version="16.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* Dropping NET 5 and 7 as they are unsupported
* Upgrading to latest dependnecies - this will give dependency graph with proper license expressions too for validators
* Using single logging package reference against 6.0 version, consumers and use later versions if they wish

Same amount of tests (12) failing in master and in this PR branch. Would be great to get a new release after/if these are accepted.