### PR TITLE
Add publish artifacts step to GitHub Actions workflow

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -1,4 +1,4 @@
-name: .NET Core
+name: CI
 
 on:
   push:
@@ -11,15 +11,25 @@ on:
 jobs:
   build:
 
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4
+
     - name: Restore
       run: dotnet restore
+
     - name: Build
       run: dotnet build --configuration Release --no-restore /property:ContinuousIntegrationBuild=True
+
 #    - name: Test
 #      run: dotnet test --configuration Release --no-restore --no-build
+
     - name: Pack
-      run: dotnet pack --configuration Release --no-restore --no-build
+      run: dotnet pack --configuration Release --no-restore --no-build -o artifacts
+
+    - name: Publish
+      uses: actions/upload-artifact@v4
+      with:
+        name: packages
+        path: 'artifacts/*.*nupkg'

--- a/DeviceDetector.NET.CacheBuilder/DeviceDetector.NET.CacheBuilder.csproj
+++ b/DeviceDetector.NET.CacheBuilder/DeviceDetector.NET.CacheBuilder.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DeviceDetector.NET.RegexEngine.PCRE/DeviceDetector.NET.RegexEngine.PCRE.csproj
+++ b/DeviceDetector.NET.RegexEngine.PCRE/DeviceDetector.NET.RegexEngine.PCRE.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+		<TargetFramework>net8.0</TargetFramework>
 		<RootNamespace>DeviceDetectorNET.RegexEngine.PCRE</RootNamespace>
+		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/DeviceDetector.NET.Tests/DeviceDetector.NET.Tests.csproj
+++ b/DeviceDetector.NET.Tests/DeviceDetector.NET.Tests.csproj
@@ -2,9 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-
     <IsPackable>false</IsPackable>
-
     <RootNamespace>DeviceDetectorNET.Tests</RootNamespace>
   </PropertyGroup>
 

--- a/DeviceDetector.NET.Web/DeviceDetector.NET.Web.csproj
+++ b/DeviceDetector.NET.Web/DeviceDetector.NET.Web.csproj
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
 	<RootNamespace>DeviceDetectorNET.Web</RootNamespace>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DeviceDetector.NET.sln
+++ b/DeviceDetector.NET.sln
@@ -17,7 +17,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DeviceDetector.NET.RegexEngine.PCRE", "DeviceDetector.NET.RegexEngine.PCRE\DeviceDetector.NET.RegexEngine.PCRE.csproj", "{94B4F635-61AC-40E4-87CC-DDA4217A0999}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DeviceDetector.NET.CacheBuilder", "DeviceDetector.Net.CacheBuilder\DeviceDetector.NET.CacheBuilder.csproj", "{E4DA874C-7C29-4D34-9C0E-103073AEE043}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DeviceDetector.NET.CacheBuilder", "DeviceDetector.NET.CacheBuilder\DeviceDetector.NET.CacheBuilder.csproj", "{E4DA874C-7C29-4D34-9C0E-103073AEE043}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DeviceDetector.NET.Web", "DeviceDetector.NET.Web\DeviceDetector.NET.Web.csproj", "{04D3C595-50EF-4E7B-8DF6-D5F997F4446D}"
 EndProject

--- a/DeviceDetector.NET/DeviceDetector.NET.csproj
+++ b/DeviceDetector.NET/DeviceDetector.NET.csproj
@@ -10,7 +10,6 @@
     <Description>The Universal Device Detection library for .NET that parses User Agents and detects devices (desktop, tablet, mobile, tv, cars, console, etc.), clients (browsers, feed readers, media players, PIMs, ...), operating systems, brands and models. This is a port of the popular PHP device-detector library to C#. For the most part you can just follow the documentation for device-detector with no issue.</Description>
     <PackageTags>parse detection-library user-agent bot-detection mobile-detection desktop tablet mobile tv cars console standard</PackageTags>
     <PackageProjectUrl>https://github.com/totpero/DeviceDetector.NET</PackageProjectUrl>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <AssemblyVersion>6.3.3.0</AssemblyVersion>
     <RepositoryUrl>https://github.com/totpero/DeviceDetector.NET</RepositoryUrl>
     <SignAssembly>false</SignAssembly>
@@ -24,6 +23,12 @@
     </PackageReleaseNotes>
     <PackageIcon>logo.jpg</PackageIcon>
     <RepositoryType>git</RepositoryType>
+
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <DebugType>portable</DebugType>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I noticed that the published NuGet package still had problems: https://nuget.info/packages/DeviceDetector.NET/6.3.3

Adding artifacts collection to GitHub action that allows to download properly built package for NuGet publish (both nupkg and snupkg should be published to NuGet.org).

Now if you download the artifacts from build summary: https://github.com/totpero/DeviceDetector.NET/actions/runs/10267431264?pr=82

NuGet package explorer gives all checks as green:

![image](https://github.com/user-attachments/assets/080612c0-4e3c-4d89-a8a9-49977868b005)

