### PR TITLE
Harmonize dependencies against NET 8

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -14,6 +14,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+
+    - uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: |
+          9.0
+
     - uses: actions/checkout@v4
 
     - name: Restore

--- a/DeviceDetector.NET/DeviceDetector.NET.csproj
+++ b/DeviceDetector.NET/DeviceDetector.NET.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net462;net6.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462;net8.0;net9.0</TargetFrameworks>
     <RootNamespace>DeviceDetectorNET</RootNamespace>
     <Version>6.4.1</Version>
     <Authors>totpero</Authors>
@@ -216,24 +216,18 @@
 
   <ItemGroup>
     <PackageReference Include="LiteDB" Version="5.0.21" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
-	<PackageReference Include="System.Text.Json" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
     <PackageReference Include="YamlDotNet" Version="16.2.1" />
   </ItemGroup>
 
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
+  </ItemGroup>
+
   <ItemGroup>
-    <None Include="..\LICENSE">
-      <Pack>True</Pack>
-      <PackagePath></PackagePath>
-    </None>
-    <None Include="..\logo.jpg">
-      <Pack>True</Pack>
-      <PackagePath>\</PackagePath>
-    </None>
-    <None Include="..\README.md">
-      <Pack>True</Pack>
-      <PackagePath>\</PackagePath>
-    </None>
+    <None Include="..\LICENSE" Pack="True" PackagePath="" />
+    <None Include="..\logo.jpg" Pack="True" PackagePath="" />
+    <None Include="..\README.md" Pack="True" PackagePath="" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
NET 9.x libraries are quite aggressive and can cause concern when consumed from NET 8 (LTS). Downgrading to 8.x and allowing consumers to upgrade with their own dependencies to later version.

* drop NET 6 support which is EOL
* make 8.0.x series default minimal
* don't require System.Text.Json when it's built-in
* add NET 9 SDK to ensure proper build

I would also argue whether NET 9 target is really necessary when NET 8 is already there and now NET 9 functionality is being used (via pre-processor directives etc). NET 8 binaries will run on NET 9 just fine.