### PR TITLE
Implement BitFaster.Caching-backed ICache

### DIFF
--- a/DeviceDetector.NET.Cache.BitFaster/BitFasterConcurrentLruCache.cs
+++ b/DeviceDetector.NET.Cache.BitFaster/BitFasterConcurrentLruCache.cs
@@ -1,0 +1,47 @@
+using BitFaster.Caching.Lru;
+
+namespace DeviceDetectorNET.Cache.BitFaster
+{
+    /// <summary>
+    /// ICache backed by BitFaster.Caching's ConcurrentLru. Unlike DictionaryCache, entries are
+    /// bounded and least-recently-used ones are evicted once <paramref name="capacity"/> is reached,
+    /// which caps memory use under high User-Agent cardinality.
+    /// </summary>
+    public class BitFasterConcurrentLruCache : ICache
+    {
+        private readonly ConcurrentLru<string, object> _cache;
+
+        public BitFasterConcurrentLruCache(int capacity = 10_000)
+        {
+            _cache = new ConcurrentLru<string, object>(capacity);
+        }
+
+        public object Fetch(string id)
+        {
+            _cache.TryGet(id, out var value);
+            return value;
+        }
+
+        public bool Contains(string id)
+        {
+            return _cache.TryGet(id, out _);
+        }
+
+        public bool Save(string id, object data, int lifeTime = 0)
+        {
+            _cache.AddOrUpdate(id, data);
+            return true;
+        }
+
+        public bool Delete(string id)
+        {
+            return _cache.TryRemove(id);
+        }
+
+        public bool FlushAll()
+        {
+            _cache.Clear();
+            return true;
+        }
+    }
+}

--- a/DeviceDetector.NET.Cache.BitFaster/DeviceDetector.NET.Cache.BitFaster.csproj
+++ b/DeviceDetector.NET.Cache.BitFaster/DeviceDetector.NET.Cache.BitFaster.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net10.0</TargetFramework>
+		<RootNamespace>DeviceDetectorNET.Cache.BitFaster</RootNamespace>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="BitFaster.Caching" Version="2.6.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\DeviceDetector.NET\DeviceDetector.NET.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/DeviceDetector.NET.Tests/Cache/BitFasterConcurrentLruCacheTest.cs
+++ b/DeviceDetector.NET.Tests/Cache/BitFasterConcurrentLruCacheTest.cs
@@ -1,0 +1,76 @@
+using Shouldly;
+using DeviceDetectorNET.Cache.BitFaster;
+using Xunit;
+
+namespace DeviceDetectorNET.Tests.Cache
+{
+    [Trait("Category", "BitFasterConcurrentLruCache")]
+    public class BitFasterConcurrentLruCacheTest
+    {
+        [Fact]
+        public void Initialize()
+        {
+            var cache = new BitFasterConcurrentLruCache();
+            cache.FlushAll();
+        }
+
+        [Fact]
+        public void TestSetNotPresent()
+        {
+            var cache = new BitFasterConcurrentLruCache();
+            var result = cache.Fetch("NotExistingKey");
+            result.ShouldBeNull();
+        }
+
+        [Fact]
+        public void TestSetAndGet()
+        {
+            var cache = new BitFasterConcurrentLruCache();
+            // add entry
+            cache.Save("key", "value");
+            cache.Fetch("key").ShouldBe("value");
+            cache.Contains("key").ShouldBeTrue();
+
+            // change entry
+            cache.Save("key", "value2");
+            cache.Fetch("key").ShouldBe("value2");
+
+            // remove entry
+            cache.Delete("key");
+            cache.Fetch("key").ShouldBeNull();
+            cache.Contains("key").ShouldBeFalse();
+
+            // flush all entries
+            cache.Save("key", "value2");
+            cache.Save("key3", "value2");
+            cache.FlushAll();
+            cache.Fetch("key").ShouldBeNull();
+            cache.Fetch("key3").ShouldBeNull();
+        }
+
+        [Fact]
+        public void TestEvictsOnceCapacityIsExceeded()
+        {
+            // ConcurrentLru approximates LRU via internal hot/warm/cold queues rather than
+            // strict recency order, so assert only that bounding actually happens, not which
+            // specific key survives.
+            var cache = new BitFasterConcurrentLruCache(capacity: 3);
+
+            for (var i = 0; i < 20; i++)
+            {
+                cache.Save($"key{i}", $"value{i}");
+            }
+
+            var survivors = 0;
+            for (var i = 0; i < 20; i++)
+            {
+                if (cache.Contains($"key{i}"))
+                {
+                    survivors++;
+                }
+            }
+
+            survivors.ShouldBeLessThan(20);
+        }
+    }
+}

--- a/DeviceDetector.NET.Tests/DeviceDetector.NET.Tests.csproj
+++ b/DeviceDetector.NET.Tests/DeviceDetector.NET.Tests.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\DeviceDetector.NET.RegexEngine.PCRE\DeviceDetector.NET.RegexEngine.PCRE.csproj" />
+    <ProjectReference Include="..\DeviceDetector.NET.Cache.BitFaster\DeviceDetector.NET.Cache.BitFaster.csproj" />
     <ProjectReference Include="..\DeviceDetector.NET\DeviceDetector.NET.csproj" />
   </ItemGroup>
 

--- a/DeviceDetector.NET.sln
+++ b/DeviceDetector.NET.sln
@@ -19,6 +19,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DeviceDetector.NET.RegexEng
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DeviceDetector.NET.CacheBuilder", "DeviceDetector.NET.CacheBuilder\DeviceDetector.NET.CacheBuilder.csproj", "{E4DA874C-7C29-4D34-9C0E-103073AEE043}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DeviceDetector.NET.Cache.BitFaster", "DeviceDetector.NET.Cache.BitFaster\DeviceDetector.NET.Cache.BitFaster.csproj", "{2C6A9F5E-3B3D-4B0A-9E3F-9B4C5D6E7F80}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DeviceDetector.NET.Web", "DeviceDetector.NET.Web\DeviceDetector.NET.Web.csproj", "{04D3C595-50EF-4E7B-8DF6-D5F997F4446D}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{9D4D2F68-CCD7-49C1-B117-4C642CC6F678}"
@@ -60,6 +62,10 @@ Global
 		{F88615DF-0E16-460A-814E-A288889DE179}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F88615DF-0E16-460A-814E-A288889DE179}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F88615DF-0E16-460A-814E-A288889DE179}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2C6A9F5E-3B3D-4B0A-9E3F-9B4C5D6E7F80}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2C6A9F5E-3B3D-4B0A-9E3F-9B4C5D6E7F80}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2C6A9F5E-3B3D-4B0A-9E3F-9B4C5D6E7F80}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2C6A9F5E-3B3D-4B0A-9E3F-9B4C5D6E7F80}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/wiki/Caching.md
+++ b/wiki/Caching.md
@@ -12,7 +12,16 @@ using DeviceDetectorNET.Cache;
 dd.SetCache(new DictionaryCache());
 ```
 
-- **`DictionaryCache`** — the built-in default. Backed by a `ConcurrentDictionary<string, object>` shared statically across all `DeviceDetector` instances in the process (equivalent to PHP's static array cache). Good for a single process/app instance; not shared across machines or app restarts.
+- **`DictionaryCache`** — the built-in default. Backed by a `ConcurrentDictionary<string, object>` shared statically across all `DeviceDetector` instances in the process (equivalent to PHP's static array cache). Good for a single process/app instance; not shared across machines or app restarts. It never evicts entries on its own, so unbounded UA cardinality means unbounded memory growth.
+- **`BitFasterConcurrentLruCache`** — provided by the separate [`DeviceDetector.NET.Cache.BitFaster`](https://github.com/totpero/DeviceDetector.NET/tree/master/DeviceDetector.NET.Cache.BitFaster) project, backed by [BitFaster.Caching](https://github.com/bitfaster/BitFaster.Caching)'s `ConcurrentLru`. Use it instead of `DictionaryCache` when you want a bounded fragment cache that evicts least-recently-used entries once a capacity is reached, rather than growing forever:
+
+  ```csharp
+  using DeviceDetectorNET.Cache.BitFaster;
+
+  dd.SetCache(new BitFasterConcurrentLruCache(capacity: 10_000));
+  ```
+
+  Like the [PCRE regex engine](Regex-Engines#pcreregexengine-optional-better-upstream-fidelity), this lives in its own project so the core package doesn't force the `BitFaster.Caching` dependency on consumers who don't need it.
 - Implement `DeviceDetectorNET.Cache.ICache` (`Fetch`, `Contains`, `Save`, `Delete`, `FlushAll`) to plug in your own store (e.g. a distributed cache) if you need cross-process sharing — there is no built-in Redis/Memcached bridge as there is for the PHP PSR-6/PSR-16 bridges, so you provide the adapter.
 
 ## 2. Persistent parse-result cache (`ParseCache`)


### PR DESCRIPTION
## Summary
- Adds `DeviceDetector.NET.Cache.BitFaster`, an optional project (mirrors `DeviceDetector.NET.RegexEngine.PCRE`) so the core package doesn't force the `BitFaster.Caching` dependency on consumers who don't need it.
- `BitFasterConcurrentLruCache` implements `ICache` backed by `BitFaster.Caching`'s `ConcurrentLru` — bounded, least-recently-used eviction once capacity is reached, unlike the unbounded default `DictionaryCache`.
- Documented in wiki/Caching.md alongside the other cache options.

Closes #80

## Test plan
- [x] `dotnet build DeviceDetector.NET.sln -c Release` succeeds
- [x] New unit tests in `BitFasterConcurrentLruCacheTest.cs` pass (init, get/set/delete/flush, bounded eviction)